### PR TITLE
Fix pgxc_ctl to improve verbose messages.

### DIFF
--- a/contrib/pgxc_ctl/bash_handler.c
+++ b/contrib/pgxc_ctl/bash_handler.c
@@ -53,7 +53,10 @@ void install_pgxc_ctl_bash(char *path, int read_prototype)
 void uninstall_pgxc_ctl_bash(char *path)
 {
 	if (path)
+	{
+		elog(DEBUG1, "uninstall_pgxc_ctl_bash: unlink %s\n", path);
 		unlink(path);
+	}
 }
 
 /*

--- a/contrib/pgxc_ctl/coord_cmd.c
+++ b/contrib/pgxc_ctl/coord_cmd.c
@@ -89,7 +89,7 @@ cmd_t *prepare_initCoordinatorMaster(char *nodeName)
 	snprintf(newCommand(cmdInitdb), MAXLINE, 
 			 "rm -rf %s;"
 			 "mkdir -p %s;"
-			 "initdb --nodename %s -D %s",
+			 "initdb --no-locale --encoding UTF-8 --nodename %s -D %s",
 			 aval(VAR_coordMasterDirs)[jj],
 			 aval(VAR_coordMasterDirs)[jj],
 			 nodeName,

--- a/contrib/pgxc_ctl/datanode_cmd.c
+++ b/contrib/pgxc_ctl/datanode_cmd.c
@@ -78,7 +78,7 @@ cmd_t *prepare_initDatanodeMaster(char *nodeName)
 	/* Build each datanode's initialize command */
 	cmd = cmdInitdb = initCmd(aval(VAR_datanodeMasterServers)[idx]);
 	snprintf(newCommand(cmdInitdb), MAXLINE,
-			 "rm -rf %s; mkdir -p %s; initdb --nodename %s -D %s",
+			 "rm -rf %s; mkdir -p %s; initdb --no-locale --encoding UTF-8 --nodename %s -D %s",
 			 aval(VAR_datanodeMasterDirs)[idx], aval(VAR_datanodeMasterDirs)[idx],
 			 aval(VAR_datanodeNames)[idx], aval(VAR_datanodeMasterDirs)[idx]);
 		

--- a/contrib/pgxc_ctl/do_shell.c
+++ b/contrib/pgxc_ctl/do_shell.c
@@ -182,7 +182,7 @@ FILE *pgxc_popen_w(char *host, const char *cmd_fmt, ...)
 	va_start(arg, cmd_fmt);
 	vsnprintf(actualCmd, MAXLINE, cmd_fmt, arg);
 	va_end(arg);
-	snprintf(sshCmd, MAXLINE, "ssh %s@%s \" %s \"", sval(VAR_pgxcUser), host, actualCmd);
+	snprintf(sshCmd, MAXLINE, "ssh %s@%s \"( source .bash_profile; %s )\"", sval(VAR_pgxcUser), host, actualCmd);
 	if ((f = popen(sshCmd, "w")) == NULL)
 		elog(ERROR, "ERROR: could not open the command \"%s\" to write, %s\n", sshCmd, strerror(errno));
 	return f;
@@ -214,7 +214,7 @@ int doImmediate(char *host, char *stdIn, const char *cmd_fmt, ...)
 	{
 		int rc1;
 		/* Remote case */
-		snprintf(actualCmd, MAXLINE, "ssh %s@%s \"( %s ) > %s 2>&1\" < %s > /dev/null 2>&1",
+		snprintf(actualCmd, MAXLINE, "ssh %s@%s \"( source .bash_profile; %s ) > %s 2>&1\" < %s > /dev/null 2>&1",
 				 sval(VAR_pgxcUser), host, cmd_wk, 
 				 createRemoteFileName(STDOUT, remoteStdout, MAXPATH),
 				 ((stdIn == NULL) || (stdIn[0] == 0)) ? "/dev/null" : stdIn);
@@ -232,9 +232,13 @@ int doImmediate(char *host, char *stdIn, const char *cmd_fmt, ...)
 					   sval(VAR_pgxcUser), host, remoteStdout);
 	}
 	elogFile(INFO, localStdout);
+	elog(DEBUG1, "doImmediate: unlink %s\n", localStdout);
 	unlink(localStdout);
 	if (stdIn && stdIn[0])
+	{
+		elog(DEBUG1, "doImmediate: unlink %s\n", stdIn);
 		unlink(stdIn);
+	}
 	return((rc));
 }
 
@@ -263,6 +267,7 @@ cmd_t *initCmd(char *host)
 
 static void clearStdin(cmd_t *cmd)
 {
+	elog(DEBUG1, "clearStdin: unlink %s\n", cmd->localStdin);
 	unlink(cmd->localStdin);
 	freeAndReset(cmd->localStdin);
 }
@@ -328,7 +333,7 @@ int doCmdEl(cmd_t *cmd)
 	{
 		/* Build actual command */
 		snprintf(allocActualCmd(cmd), MAXLINE,
-				 "ssh %s@%s \"( %s ) > %s 2>&1\" < %s > /dev/null 2>&1",
+				 "ssh %s@%s \"( source .bash_profile; %s ) > %s 2>&1\" < %s > /dev/null 2>&1",
 				 sval(VAR_pgxcUser),
 				 cmd->host,
 				 cmd->command,
@@ -534,11 +539,17 @@ void do_cleanCmdEl(cmd_t *cmd)
 	if (cmd)
 	{
 		if (cmd->localStdout)
+		{
+			elog(DEBUG1, "do_cleanCmdEl: unlink %s\n", cmd->localStdout);
 			unlink(cmd->localStdout);
+		}
 		Free(cmd->localStdout);
 		Free(cmd->msg);
 		if (cmd->localStdin)
+		{
+			elog(DEBUG1, "do_cleanCmdEl: unlink %s\n", cmd->localStdin);
 			unlink(cmd->localStdin);
+		}
 		Free(cmd->localStdin);
 		if (cmd->remoteStdout)
 			doImmediateRaw("ssh %s@%s \"rm -f %s > /dev/null 2>&1\"", sval(VAR_pgxcUser), cmd->host, cmd->remoteStdout);

--- a/contrib/pgxc_ctl/pgxc_ctl.c
+++ b/contrib/pgxc_ctl/pgxc_ctl.c
@@ -76,6 +76,8 @@ char *defaultDatabase;
 FILE *inF;
 FILE *outF;
 
+static char *verbose = NULL;
+
 static void build_pgxc_ctl_home(char *home);
 static void trim_trailing_slash(char *path);
 static void startLog(char *path, char *logFileNam);
@@ -415,8 +417,8 @@ static void setup_my_env(void)
 	setDefaultIfNeeded(VAR_configFile, "pgxc_ctl.conf");
 	setDefaultIfNeeded(VAR_echoAll, "n");
 	setDefaultIfNeeded(VAR_debug, "n");
-	setDefaultIfNeeded(VAR_printMessage, "info");
-	setDefaultIfNeeded(VAR_logMessage, "info");
+	setDefaultIfNeeded(VAR_printMessage, (verbose == NULL ? "info" : "debug3"));
+	setDefaultIfNeeded(VAR_logMessage, (verbose == NULL ? "info" : "debug3"));
 	setDefaultIfNeeded(VAR_pgxcCtlName, DefaultName);
 	myName = Strdup(sval(VAR_pgxcCtlName));
 	setDefaultIfNeeded(VAR_defaultDatabase, DefaultDatabase);
@@ -430,7 +432,6 @@ int main(int argc, char *argv[])
 	char *configuration = NULL;
 	char *infile = NULL;
 	char *outfile = NULL;
-	char *verbose = NULL;
 	int version_opt = 0;
 	char *logdir = NULL;
 	char *logfile = NULL;


### PR DESCRIPTION
  "pgxc_ctl -v" sets its log level as DEBUG3 instead of INFO.

Fix pgxc_ctl on SSH execution to load ".bash_profile" on remote node.

  SSH does not read .bash_profile when executing a command
  on a remote host (a.k.a. non-interactive mode).
  See bash(1) for more info.

Fix pgxc_ctl to call initdb with "--no-locale" and "--encoding UTF-8" options.
